### PR TITLE
Creates DatabaseNotifications that use the MongoDB classes

### DIFF
--- a/src/Jenssegers/Mongodb/Auth/User.php
+++ b/src/Jenssegers/Mongodb/Auth/User.php
@@ -7,11 +7,12 @@ use Illuminate\Foundation\Auth\Access\Authorizable;
 use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
 use Illuminate\Contracts\Auth\Access\Authorizable as AuthorizableContract;
 use Illuminate\Contracts\Auth\CanResetPassword as CanResetPasswordContract;
+use Jenssegers\Mongodb\Notifications\Notifiable;
 
 class User extends Model implements
     AuthenticatableContract,
     AuthorizableContract,
     CanResetPasswordContract
 {
-    use Authenticatable, Authorizable, CanResetPassword;
+    use Authenticatable, Authorizable, CanResetPassword, Notifiable;
 }

--- a/src/Jenssegers/Mongodb/Notifications/DatabaseNotification.php
+++ b/src/Jenssegers/Mongodb/Notifications/DatabaseNotification.php
@@ -1,0 +1,89 @@
+<?php namespace Jenssegers\Mongodb\Notifications;
+
+use Illuminate\Notifications\DatabaseNotificationCollection;
+use Jenssegers\Mongodb\Eloquent\Model;
+
+class DatabaseNotification extends Model
+{
+    /**
+     * Indicates if the IDs are auto-incrementing.
+     *
+     * @var bool
+     */
+    public $incrementing = false;
+
+    /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'notifications';
+
+    /**
+     * The guarded attributes on the model.
+     *
+     * @var array
+     */
+    protected $guarded = [];
+
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'data' => 'array',
+        'read_at' => 'datetime',
+    ];
+
+    /**
+     * Get the notifiable entity that the notification belongs to.
+     */
+    public function notifiable()
+    {
+        return $this->morphTo();
+    }
+
+    /**
+     * Mark the notification as read.
+     *
+     * @return void
+     */
+    public function markAsRead()
+    {
+        if (is_null($this->read_at)) {
+            $this->forceFill(['read_at' => $this->freshTimestamp()])->save();
+        }
+    }
+
+    /**
+     * Determine if a notification has been read.
+     *
+     * @return bool
+     */
+    public function read()
+    {
+        return $this->read_at !== null;
+    }
+
+    /**
+     * Determine if a notification has not been read.
+     *
+     * @return bool
+     */
+    public function unread()
+    {
+        return $this->read_at === null;
+    }
+
+    /**
+     * Create a new database notification collection instance.
+     *
+     * @param  array  $models
+     * @return \Illuminate\Notifications\DatabaseNotificationCollection
+     */
+    public function newCollection(array $models = [])
+    {
+        return new DatabaseNotificationCollection($models);
+    }
+}

--- a/src/Jenssegers/Mongodb/Notifications/HasDatabaseNotifications.php
+++ b/src/Jenssegers/Mongodb/Notifications/HasDatabaseNotifications.php
@@ -1,0 +1,31 @@
+<?php namespace Jenssegers\Mongodb\Notifications;
+
+trait HasDatabaseNotifications
+{
+    /**
+     * Get the entity's notifications.
+     */
+    public function notifications()
+    {
+        return $this->morphMany(DatabaseNotification::class, 'notifiable')
+                    ->orderBy('created_at', 'desc');
+    }
+
+    /**
+     * Get the entity's read notifications.
+     */
+    public function readNotifications()
+    {
+        return $this->notifications()
+                    ->whereNotNull('read_at');
+    }
+
+    /**
+     * Get the entity's unread notifications.
+     */
+    public function unreadNotifications()
+    {
+        return $this->notifications()
+                    ->whereNull('read_at');
+    }
+}

--- a/src/Jenssegers/Mongodb/Notifications/Notifiable.php
+++ b/src/Jenssegers/Mongodb/Notifications/Notifiable.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Jenssegers\Mongodb\Notifications;
+
+use Illuminate\Notifications\RoutesNotifications;
+
+trait Notifiable
+{
+    use HasDatabaseNotifications, RoutesNotifications;
+}


### PR DESCRIPTION
Fixes calls to `$notifiable->notify(new MyNotification())` if `MyNotification` uses the `database` channel. This used to raise an error because it used the standard Eloquent `DatabaseNotification` class which failed if there was no PDO instance.

This new classes are copied from the original Eloquent classes, but use the correct MongoDB counterparts.

Fixes: https://github.com/jenssegers/laravel-mongodb/issues/1067 